### PR TITLE
support SSL SNI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,9 @@ python-subunit==0.0.18
 rdflib==3.1.0
 selenium==2.45.0
 coverage==3.7.1
+pyasn1==0.1.8
+pyOpenSSL==0.15.1
+ndg-httpsclient==0.4.0
 requests==2.7.0
 logilab-common==0.59.0
 logilab-astng==0.24.1


### PR DESCRIPTION
At some point recently, we deployed SSL certificates to neptune for
non-CCNMTL domains. This uses [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to get the
correct certificate to the browser.

At this point, SNI is generally well supported enough that most things
just work. Unfortunately, python's built in http/ssl libraries don't support
SNI out of the box. According to this:

http://docs.python-requests.org/en/latest/community/faq/#what-are-hostname-doesn-t-match-errors

and this:

https://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484

there need to be a couple extra libraries installed for SNI.

Where this hits us is with Sentry. `sentry.ccnmtl.columbia.edu` resolves
to neptune, which is now using SNI. So all of our apps need to be
patched to handle SNI so they can submit errors to Sentry.