### PR TITLE
:arrow_up: ccnmtlsettings 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,4 +84,4 @@ python-dateutil==2.4.2
 django-storages-redux==1.3
 django-cacheds3storage==0.1.2
 
-ccnmtlsettings==0.1.0
+ccnmtlsettings==0.1.3


### PR DESCRIPTION
Uploaded images are broken in production. A preliminary step to fixing this is getting the new ccnmtlsettings, which doesn't look for the `compressor` folder in the s3 bucket.