### PR TITLE
convert from unique ForeignKeys to OneToOneFields

### DIFF
--- a/wacep/certificates/migrations/0002_auto_20160623_0937.py
+++ b/wacep/certificates/migrations/0002_auto_20160623_0937.py
@@ -1,0 +1,20 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certificates', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='certificatecourse',
+            name='section',
+            field=models.OneToOneField(null=True, blank=True, to='pagetree.Section', help_text=b'The section corresponding to this course.'),
+        ),
+    ]

--- a/wacep/certificates/models.py
+++ b/wacep/certificates/models.py
@@ -9,10 +9,10 @@ class CertificateCourse (models.Model):
     name = models.CharField(max_length=256, default='')
     order_rank = models.IntegerField(default=0, null=True, blank=True)
 
-    section = models.ForeignKey(
+    section = models.OneToOneField(
         Section, null=True, blank=True,
         help_text="The section corresponding to this course.",
-        unique=True, limit_choices_to={'depth': 2})
+        limit_choices_to={'depth': 2})
 
     description = models.TextField(
         blank=True, default='',

--- a/wacep/weatherroulette/migrations/0004_auto_20160623_0938.py
+++ b/wacep/weatherroulette/migrations/0004_auto_20160623_0938.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('weatherroulette', '0003_auto_20160617_0848'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='gamestate',
+            name='user',
+            field=models.OneToOneField(to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/wacep/weatherroulette/models.py
+++ b/wacep/weatherroulette/models.py
@@ -9,7 +9,7 @@ class GameState(models.Model):
     """
     A GameState holds all the data needed for a user's game.
     """
-    user = models.ForeignKey(User, unique=True)
+    user = models.OneToOneField(User)
 
     current_round = models.ForeignKey('PuzzleRound', null=True)
 


### PR DESCRIPTION
eliminates:

```
WARNINGS:
certificates.CertificateCourse.section: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
weatherroulette.GameState.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
```